### PR TITLE
Make use of device.logs_channel if there is one

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ Documentation
 
 
 * [logs](#module_logs)
-  * [.subscribe(pubnubKeys, uuid)](#module_logs.subscribe) ⇒ <code>EventEmitter</code>
-  * [.history(pubnubKeys, uuid)](#module_logs.history) ⇒ <code>Promise.&lt;Array.&lt;String&gt;&gt;</code>
+  * [.subscribe(pubnubKeys, device)](#module_logs.subscribe) ⇒ <code>EventEmitter</code>
+  * [.history(pubnubKeys, device)](#module_logs.history) ⇒ <code>Promise.&lt;Array.&lt;String&gt;&gt;</code>
 
 <a name="module_logs.subscribe"></a>
-### logs.subscribe(pubnubKeys, uuid) ⇒ <code>EventEmitter</code>
+### logs.subscribe(pubnubKeys, device) ⇒ <code>EventEmitter</code>
 This function emits various events:
 
 - `line`: When a log line arrives, passing a string as an argument.
@@ -55,14 +55,15 @@ The object returned by this function also contains the following functions:
 | pubnubKeys | <code>Object</code> | PubNub keys |
 | pubnubKeys.subscribe_key | <code>String</code> | subscribe key |
 | pubnubKeys.publish_key | <code>String</code> | publish key |
-| uuid | <code>String</code> | uuid |
+| device | <code>Object</code> | device |
 
 **Example**  
 ```js
 deviceLogs = logs.subscribe
 	subscribe_key: '...'
 	publish_key: '...'
-, '...'
+,
+		uuid: '...'
 
 deviceLogs.on 'line', (line) ->
 		console.log(line)
@@ -71,7 +72,7 @@ deviceLogs.on 'error', (error) ->
 		throw error
 ```
 <a name="module_logs.history"></a>
-### logs.history(pubnubKeys, uuid) ⇒ <code>Promise.&lt;Array.&lt;String&gt;&gt;</code>
+### logs.history(pubnubKeys, device) ⇒ <code>Promise.&lt;Array.&lt;String&gt;&gt;</code>
 **Kind**: static method of <code>[logs](#module_logs)</code>  
 **Summary**: Get device logs history  
 **Returns**: <code>Promise.&lt;Array.&lt;String&gt;&gt;</code> - device logs history  
@@ -82,14 +83,15 @@ deviceLogs.on 'error', (error) ->
 | pubnubKeys | <code>Object</code> | PubNub keys |
 | pubnubKeys.subscribe_key | <code>String</code> | subscribe key |
 | pubnubKeys.publish_key | <code>String</code> | publish key |
-| uuid | <code>String</code> | uuid |
+| device | <code>Object</code> | device |
 
 **Example**  
 ```js
 logs.history
 	subscribe_key: '...'
 	publish_key: '...'
-, '...'
+,
+		uuid: '...'
 .then (messages) ->
 	for message in messages
 		console.log(message)

--- a/build/logs.js
+++ b/build/logs.js
@@ -56,7 +56,7 @@ utils = require('./utils');
  * @param {Object} pubnubKeys - PubNub keys
  * @param {String} pubnubKeys.subscribe_key - subscribe key
  * @param {String} pubnubKeys.publish_key - publish key
- * @param {String} uuid - uuid
+ * @param {Object} device - device
  *
  * @returns {EventEmitter} logs
  *
@@ -64,7 +64,8 @@ utils = require('./utils');
  * deviceLogs = logs.subscribe
  * 	subscribe_key: '...'
  * 	publish_key: '...'
- * , '...'
+ * ,
+ *		uuid: '...'
  *
  * deviceLogs.on 'line', (line) ->
  *		console.log(line)
@@ -73,9 +74,9 @@ utils = require('./utils');
  *		throw error
  */
 
-exports.subscribe = function(pubnubKeys, uuid) {
+exports.subscribe = function(pubnubKeys, device) {
   var channel, emitter, instance;
-  channel = utils.getChannel(uuid);
+  channel = utils.getChannel(device);
   instance = pubnub.getInstance(pubnubKeys);
   emitter = new EventEmitter();
   instance.subscribe({
@@ -105,7 +106,7 @@ exports.subscribe = function(pubnubKeys, uuid) {
  * @param {Object} pubnubKeys - PubNub keys
  * @param {String} pubnubKeys.subscribe_key - subscribe key
  * @param {String} pubnubKeys.publish_key - publish key
- * @param {String} uuid - uuid
+ * @param {Object} device - device
  *
  * @returns {Promise<String[]>} device logs history
  *
@@ -113,17 +114,18 @@ exports.subscribe = function(pubnubKeys, uuid) {
  * logs.history
  * 	subscribe_key: '...'
  * 	publish_key: '...'
- * , '...'
+ * ,
+ *		uuid: '...'
  * .then (messages) ->
  * 	for message in messages
  * 		console.log(message)
  */
 
-exports.history = function(pubnubKeys, uuid) {
+exports.history = function(pubnubKeys, device) {
   return Promise["try"](function() {
     var channel, instance;
     instance = pubnub.getInstance(pubnubKeys);
-    channel = utils.getChannel(uuid);
+    channel = utils.getChannel(device);
     return pubnub.history(instance, channel);
   });
 };

--- a/build/utils.js
+++ b/build/utils.js
@@ -28,12 +28,12 @@ THE SOFTWARE.
  * @function
  * @protected
  *
- * @param {String} uuid - device uuid
+ * @param {Object} device - device
  * @returns {String} logs channel
  *
  * @example
  * channel = utils.getChannel('...')
  */
-exports.getChannel = function(uuid) {
-  return "device-" + uuid + "-logs";
+exports.getChannel = function(device) {
+  return device.logs_channel || ("device-" + device.uuid + "-logs");
 };

--- a/lib/logs.coffee
+++ b/lib/logs.coffee
@@ -49,7 +49,7 @@ utils = require('./utils')
 # @param {Object} pubnubKeys - PubNub keys
 # @param {String} pubnubKeys.subscribe_key - subscribe key
 # @param {String} pubnubKeys.publish_key - publish key
-# @param {String} uuid - uuid
+# @param {Object} device - device
 #
 # @returns {EventEmitter} logs
 #
@@ -57,7 +57,8 @@ utils = require('./utils')
 # deviceLogs = logs.subscribe
 # 	subscribe_key: '...'
 # 	publish_key: '...'
-# , '...'
+# ,
+#		uuid: '...'
 #
 # deviceLogs.on 'line', (line) ->
 #		console.log(line)
@@ -65,8 +66,8 @@ utils = require('./utils')
 # deviceLogs.on 'error', (error) ->
 #		throw error
 ###
-exports.subscribe = (pubnubKeys, uuid) ->
-	channel = utils.getChannel(uuid)
+exports.subscribe = (pubnubKeys, device) ->
+	channel = utils.getChannel(device)
 	instance = pubnub.getInstance(pubnubKeys)
 	emitter = new EventEmitter()
 
@@ -91,7 +92,7 @@ exports.subscribe = (pubnubKeys, uuid) ->
 # @param {Object} pubnubKeys - PubNub keys
 # @param {String} pubnubKeys.subscribe_key - subscribe key
 # @param {String} pubnubKeys.publish_key - publish key
-# @param {String} uuid - uuid
+# @param {Object} device - device
 #
 # @returns {Promise<String[]>} device logs history
 #
@@ -99,13 +100,14 @@ exports.subscribe = (pubnubKeys, uuid) ->
 # logs.history
 # 	subscribe_key: '...'
 # 	publish_key: '...'
-# , '...'
+# ,
+#		uuid: '...'
 # .then (messages) ->
 # 	for message in messages
 # 		console.log(message)
 ###
-exports.history = (pubnubKeys, uuid) ->
+exports.history = (pubnubKeys, device) ->
 	Promise.try ->
 		instance = pubnub.getInstance(pubnubKeys)
-		channel = utils.getChannel(uuid)
+		channel = utils.getChannel(device)
 		return pubnub.history(instance, channel)

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -27,11 +27,11 @@ THE SOFTWARE.
 # @function
 # @protected
 #
-# @param {String} uuid - device uuid
+# @param {Object} device - device
 # @returns {String} logs channel
 #
 # @example
 # channel = utils.getChannel('...')
 ###
-exports.getChannel = (uuid) ->
-	return "device-#{uuid}-logs"
+exports.getChannel = (device) ->
+	return device.logs_channel or "device-#{device.uuid}-logs"

--- a/tests/logs.spec.coffee
+++ b/tests/logs.spec.coffee
@@ -32,7 +32,7 @@ describe 'Logs:', ->
 				@pubnubGetInstanceStub.restore()
 
 			it 'should send message events', (done) ->
-				pubnubStream = logs.subscribe(pubnubKeys, 'asdf')
+				pubnubStream = logs.subscribe(pubnubKeys, uuid: 'asdf')
 				lines = []
 				pubnubStream.on 'line', (line) ->
 					lines.push(line)
@@ -55,7 +55,7 @@ describe 'Logs:', ->
 				@pubnubGetInstanceStub.restore()
 
 			it 'should receive the error', (done) ->
-				pubnubStream = logs.subscribe(pubnubKeys, 'asdf')
+				pubnubStream = logs.subscribe(pubnubKeys, uuid: 'asdf')
 				pubnubStream.on 'error', (error) ->
 					m.chai.expect(error).to.be.an.instanceof(Error)
 					m.chai.expect(error.message).to.equal('pubnub error')
@@ -73,7 +73,7 @@ describe 'Logs:', ->
 				@pubnubGetInstanceStub.restore()
 
 			it 'should reject with that error', ->
-				promise = logs.history(pubnubKeys, 'asdf')
+				promise = logs.history(pubnubKeys, uuid: 'asdf')
 				m.chai.expect(promise).to.be.rejectedWith('pubnub error')
 
 		describe 'given an instance that reacts to a valid channel', ->
@@ -101,7 +101,7 @@ describe 'Logs:', ->
 			describe 'given the correct uuid', ->
 
 				it 'should eventually return the messages', ->
-					promise = logs.history(pubnubKeys, 'asdf')
+					promise = logs.history(pubnubKeys, uuid: 'asdf')
 					m.chai.expect(promise).to.eventually.become([ 'Foo', 'Bar', 'Baz' ])
 
 		describe 'given an instance that returns an error', ->
@@ -118,5 +118,5 @@ describe 'Logs:', ->
 				@pubnubGetInstanceStub.restore()
 
 			it 'should reject with the error', ->
-				promise = logs.history(pubnubKeys, 'asdf')
+				promise = logs.history(pubnubKeys, uuid: 'asdf')
 				m.chai.expect(promise).to.be.rejectedWith('logs error')

--- a/tests/utils.spec.coffee
+++ b/tests/utils.spec.coffee
@@ -5,5 +5,18 @@ describe 'Utils:', ->
 
 	describe '.getChannel()', ->
 
-		it 'should return the channel', ->
-			m.chai.expect(utils.getChannel('asdf')).to.equal('device-asdf-logs')
+		describe 'given a logs_channel property', ->
+
+			it 'should return the property', ->
+				device =
+					uuid: 'asdf'
+					logs_channel: 'qwer'
+				m.chai.expect(utils.getChannel(device)).to.equal('qwer')
+
+		describe 'given no logs_channel property', ->
+
+			it 'should use the uuid', ->
+				device =
+					uuid: 'asdf'
+
+				m.chai.expect(utils.getChannel(device)).to.equal('device-asdf-logs')


### PR DESCRIPTION
Devices now include a `logs_channel` determining the pubnub channel
where we should be listening at.

Breaking changes:
- The public functions now take a device object instead of a uuid.
