### PR TITLE
Fix logs channel surrounding usage

### DIFF
--- a/build/utils.js
+++ b/build/utils.js
@@ -35,5 +35,5 @@ THE SOFTWARE.
  * channel = utils.getChannel('...')
  */
 exports.getChannel = function(device) {
-  return device.logs_channel || ("device-" + device.uuid + "-logs");
+  return "device-" + (device.logs_channel || device.uuid) + "-logs";
 };

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -34,4 +34,4 @@ THE SOFTWARE.
 # channel = utils.getChannel('...')
 ###
 exports.getChannel = (device) ->
-	return device.logs_channel or "device-#{device.uuid}-logs"
+	return "device-#{device.logs_channel or device.uuid}-logs"

--- a/tests/utils.spec.coffee
+++ b/tests/utils.spec.coffee
@@ -11,7 +11,7 @@ describe 'Utils:', ->
 				device =
 					uuid: 'asdf'
 					logs_channel: 'qwer'
-				m.chai.expect(utils.getChannel(device)).to.equal('qwer')
+				m.chai.expect(utils.getChannel(device)).to.equal('device-qwer-logs')
 
 		describe 'given no logs_channel property', ->
 


### PR DESCRIPTION
The `logs_channel` property still needs to be surrounded by
`device-{{channel}}-logs`.
