### PR TITLE
Emit back `.isSystem` and `.timestamp` along with every message

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ Documentation
 
 * [logs](#module_logs)
     * [.subscribe(pubnubKeys, device)](#module_logs.subscribe) ⇒ <code>EventEmitter</code>
-    * [.history(pubnubKeys, device)](#module_logs.history) ⇒ <code>Promise.&lt;Array.&lt;String&gt;&gt;</code>
+    * [.history(pubnubKeys, device)](#module_logs.history) ⇒ <code>Promise.&lt;Array.&lt;Object&gt;&gt;</code>
 
 <a name="module_logs.subscribe"></a>
 
 ### logs.subscribe(pubnubKeys, device) ⇒ <code>EventEmitter</code>
 This function emits various events:
 
-- `line`: When a log line arrives, passing a string as an argument.
+- `line`: When a log line arrives, passing an object as an argument.
 - `error`: When an error occurs, passing an error instance as an argument.
 
 The object returned by this function also contains the following functions:
@@ -69,17 +69,19 @@ deviceLogs = logs.subscribe
 	uuid: '...'
 
 deviceLogs.on 'line', (line) ->
-	console.log(line)
+	console.log(line.message)
+	console.log(line.isSystem)
+	console.log(line.timestamp)
 
 deviceLogs.on 'error', (error) ->
 	throw error
 ```
 <a name="module_logs.history"></a>
 
-### logs.history(pubnubKeys, device) ⇒ <code>Promise.&lt;Array.&lt;String&gt;&gt;</code>
+### logs.history(pubnubKeys, device) ⇒ <code>Promise.&lt;Array.&lt;Object&gt;&gt;</code>
 **Kind**: static method of <code>[logs](#module_logs)</code>  
 **Summary**: Get device logs history  
-**Returns**: <code>Promise.&lt;Array.&lt;String&gt;&gt;</code> - device logs history  
+**Returns**: <code>Promise.&lt;Array.&lt;Object&gt;&gt;</code> - device logs history  
 **Access:** public  
 
 | Param | Type | Description |
@@ -96,9 +98,11 @@ logs.history
 	publish_key: '...'
 ,
 	uuid: '...'
-.then (messages) ->
-	for message in messages
-		console.log(message)
+.then (lines) ->
+	for line in lines
+		console.log(line.message)
+		console.log(line.isSystem)
+		console.log(line.timestamp)
 ```
 
 Support

--- a/build/logs.js
+++ b/build/logs.js
@@ -38,7 +38,7 @@ utils = require('./utils');
  *
  * @description This function emits various events:
  *
- * - `line`: When a log line arrives, passing a string as an argument.
+ * - `line`: When a log line arrives, passing an object as an argument.
  * - `error`: When an error occurs, passing an error instance as an argument.
  *
  * The object returned by this function also contains the following functions:
@@ -60,7 +60,9 @@ utils = require('./utils');
  * 	uuid: '...'
  *
  * deviceLogs.on 'line', (line) ->
- * 	console.log(line)
+ * 	console.log(line.message)
+ * 	console.log(line.isSystem)
+ * 	console.log(line.timestamp)
  *
  * deviceLogs.on 'error', (error) ->
  * 	throw error
@@ -76,7 +78,7 @@ exports.subscribe = function(pubnubKeys, device) {
     restore: true,
     message: function(payload) {
       return _.each(utils.extractMessages(payload), function(data) {
-        return emitter.emit('line', data.message);
+        return emitter.emit('line', data);
       });
     },
     error: function(error) {
@@ -102,7 +104,7 @@ exports.subscribe = function(pubnubKeys, device) {
  * @param {String} pubnubKeys.publish_key - publish key
  * @param {Object} device - device
  *
- * @returns {Promise<String[]>} device logs history
+ * @returns {Promise<Object[]>} device logs history
  *
  * @example
  * logs.history
@@ -110,9 +112,11 @@ exports.subscribe = function(pubnubKeys, device) {
  * 	publish_key: '...'
  * ,
  * 	uuid: '...'
- * .then (messages) ->
- * 	for message in messages
- * 		console.log(message)
+ * .then (lines) ->
+ * 	for line in lines
+ * 		console.log(line.message)
+ * 		console.log(line.isSystem)
+ * 		console.log(line.timestamp)
  */
 
 exports.history = function(pubnubKeys, device) {
@@ -121,7 +125,5 @@ exports.history = function(pubnubKeys, device) {
     instance = pubnub.getInstance(pubnubKeys);
     channel = utils.getChannel(device);
     return pubnub.history(instance, channel);
-  }).map(function(line) {
-    return _.map(utils.extractMessages(line), 'message');
-  }).then(_.flatten);
+  }).map(utils.extractMessages).then(_.flatten);
 };

--- a/tests/logs.spec.coffee
+++ b/tests/logs.spec.coffee
@@ -38,7 +38,23 @@ describe 'Logs:', ->
 					lines.push(line)
 
 					if lines.length is 3
-						m.chai.expect(lines).to.deep.equal([ 'foo', 'bar', 'baz' ])
+						m.chai.expect(lines).to.deep.equal [
+							{
+								message: 'foo'
+								isSystem: false
+								timestamp: null
+							}
+							{
+								message: 'bar'
+								isSystem: false
+								timestamp: null
+							}
+							{
+								message: 'baz'
+								isSystem: false
+								timestamp: null
+							}
+						]
 						done()
 
 		describe 'given an instance that connects and sends an error', ->
@@ -102,7 +118,23 @@ describe 'Logs:', ->
 
 				it 'should eventually return the messages', ->
 					promise = logs.history(pubnubKeys, uuid: 'asdf')
-					m.chai.expect(promise).to.eventually.become([ 'Foo', 'Bar', 'Baz' ])
+					m.chai.expect(promise).to.eventually.become [
+						{
+							message: 'Foo'
+							isSystem: false
+							timestamp: null
+						}
+						{
+							message: 'Bar'
+							isSystem: false
+							timestamp: null
+						}
+						{
+							message: 'Baz'
+							isSystem: false
+							timestamp: null
+						}
+					]
 
 		describe 'given an instance that returns an error', ->
 


### PR DESCRIPTION
`utils.extractMessages()` returns objects containing the following
properties for every line:
- `message`
- `timestamp`
- `isSystem`

We deliberately emitted back only `.message` in order to not introduce a
breaking change in the latest version.

Signed-off-by: Juan Cruz Viotti jviottidc@gmail.com
